### PR TITLE
Fix/테스트에서 애플리케이션 컨텍스트 관련 에러 수정 (#16)

### DIFF
--- a/xuni-cafe-api/src/test/java/com/xuni/cafe/api/place/presentation/PlaceControllerTest.java
+++ b/xuni-cafe-api/src/test/java/com/xuni/cafe/api/place/presentation/PlaceControllerTest.java
@@ -19,7 +19,7 @@ import java.util.List;
 import static com.xuni.cafe.api.place.dto.response.PlaceAPiMessage.ENROLL;
 import static com.xuni.cafe.api.place.dto.response.PlaceAPiMessage.INVALID_OPERATION;
 
-@SpringBootTest
+@SpringBootTest(properties = "spring.main.web-application-type=reactive")
 @AutoConfigureWebTestClient
 class PlaceControllerTest {
 


### PR DESCRIPTION
batch 모듈에서 web 의존성을 추가한 이후로 컨테이너를 제대로 띄우지 못함
SpringBootTest properties 설정을 통해 해결